### PR TITLE
Use constexpr algorithms

### DIFF
--- a/src/convopt/convopt.hpp
+++ b/src/convopt/convopt.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "src/dualnumbers/dualnumbers.hpp"
 #include "src/spaces/spaces.hpp"
 
@@ -5,37 +7,37 @@
 #include <array>
 #include <iostream>
 
-#pragma once
-
 namespace convopt {
 
 using dualnumbers::DualNumber;
 using spaces::Point;
 using spaces::Vector;
 
-template <std::size_t I, std::size_t N, class T, std::size_t... Is>
-constexpr auto
-evaluated_point_at_index(Point<T, N> x, std::index_sequence<Is...>)
-    -> Point<DualNumber, N>
-{
-    Point<DualNumber, N> point = {
-        DualNumber{x.template get<Is>(), Is == I ? 1.0F : 0.0F}...};
-    return point;
-}
-
-template <std::size_t N, class T, class F, std::size_t... Is>
-constexpr auto gradient_impl(Point<T, N> x, F cost, std::index_sequence<Is...>)
-    -> Vector<T, N>
-{
-    return {
-        (cost(evaluated_point_at_index<Is>(x, std::make_index_sequence<N>{}))
-             .imag())...};
-}
-
 template <std::size_t N, class T, class F>
-constexpr auto gradient(Point<T, N> x, F cost) -> Vector<T, N>
+constexpr auto gradient(Point<T, N> p, F cost) -> Vector<T, N>
 {
-    return gradient_impl(x, cost, std::make_index_sequence<N>{});
+    const auto d = [&p]() {
+        auto d = Point<DualNumber, N>{};
+
+        std::ranges::transform(
+            p.coords().cbegin(),
+            p.coords().cend(),
+            d.coords().begin(),
+            [](auto x) { return DualNumber{x}; });
+
+        return d;
+    }();
+
+    auto r = Vector<T, N>{};
+
+    for (auto i = 0U; i < N; ++i) {
+        auto di = d;
+        di.coords()[i].imag() = 1.0F;
+
+        r.coords()[i] = cost(di).imag();
+    }
+
+    return r;
 }
 
 template <std::size_t N, class T, class F>

--- a/src/convopt/convopt.hpp
+++ b/src/convopt/convopt.hpp
@@ -19,11 +19,9 @@ constexpr auto gradient(Point<T, N> p, F cost) -> Vector<T, N>
     const auto d = [&p]() {
         auto d = Point<DualNumber, N>{};
 
-        std::ranges::transform(
-            p.coords().cbegin(),
-            p.coords().cend(),
-            d.coords().begin(),
-            [](auto x) { return DualNumber{x}; });
+        std::ranges::transform(p.cbegin(), p.cend(), d.begin(), [](auto x) {
+            return DualNumber{x};
+        });
 
         return d;
     }();
@@ -32,9 +30,9 @@ constexpr auto gradient(Point<T, N> p, F cost) -> Vector<T, N>
 
     for (auto i = 0U; i < N; ++i) {
         auto di = d;
-        di.coords()[i].imag() = 1.0F;
+        di[i].imag() = 1.0F;
 
-        r.coords()[i] = cost(di).imag();
+        r[i] = cost(di).imag();
     }
 
     return r;

--- a/src/convopt/convopt.hpp
+++ b/src/convopt/convopt.hpp
@@ -18,11 +18,9 @@ constexpr auto gradient(Point<T, N> p, F cost) -> Vector<T, N>
 {
     const auto d = [&p]() {
         auto d = Point<DualNumber, N>{};
-
-        std::ranges::transform(p.cbegin(), p.cend(), d.begin(), [](auto x) {
+        std::transform(p.cbegin(), p.cend(), d.begin(), [](auto x) {
             return DualNumber{x};
         });
-
         return d;
     }();
 

--- a/src/dualnumbers/dualnumbers.hpp
+++ b/src/dualnumbers/dualnumbers.hpp
@@ -75,8 +75,11 @@ class DualNumber {
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     constexpr DualNumber(float r, float e) : r_{r}, e_{e} {}
 
-    [[nodiscard]] constexpr auto real() const -> float { return r_; }
-    [[nodiscard]] constexpr auto imag() const -> float { return e_; }
+    [[nodiscard]] constexpr auto real() & -> float& { return r_; }
+    [[nodiscard]] constexpr auto real() const& -> const float& { return r_; }
+
+    [[nodiscard]] constexpr auto imag() & -> float& { return e_; }
+    [[nodiscard]] constexpr auto imag() const& -> const float& { return e_; }
 };
 
 }  // namespace dualnumbers

--- a/src/dualnumbers/dualnumbers.hpp
+++ b/src/dualnumbers/dualnumbers.hpp
@@ -50,16 +50,7 @@ class DualNumber {
     }
 
     friend constexpr auto operator==(DualNumber const& x, DualNumber const& y)
-        -> bool
-    {
-        return (x.real() == y.real()) && (x.imag() == y.imag());
-    }
-
-    friend constexpr auto operator!=(DualNumber const& x, DualNumber const& y)
-        -> bool
-    {
-        return !(x == y);
-    }
+        -> bool = default;
 
     friend constexpr auto operator-(DualNumber const& x) -> DualNumber
     {

--- a/src/spaces/spaces.hpp
+++ b/src/spaces/spaces.hpp
@@ -14,32 +14,41 @@ template <class T>
 class Entity {};
 
 template <class T, std::size_t N, template <class, std::size_t> class Derived>
-class Entity<Derived<T, N>> {
+class Entity<Derived<T, N>> : std::array<T, N> {
   public:
     static constexpr std::size_t size{N};
     using coord_type = T;
     using coords_type = std::array<coord_type, size>;
 
-    [[nodiscard]] constexpr auto coords() & -> coords_type& { return coords_; }
+    [[nodiscard]] constexpr auto coords() & -> coords_type&
+    {
+        return static_cast<coords_type&>(*this);
+    }
     [[nodiscard]] constexpr auto coords() const& -> const coords_type&
     {
-        return coords_;
+        return static_cast<const coords_type&>(*this);
     }
 
     template <std::size_t I>
-    [[nodiscard]] constexpr auto get() const -> coord_type
+    [[nodiscard]] constexpr auto get() const& -> const coord_type&
     {
-        return std::get<I>(coords_);
+        return std::get<I>(coords());
     }
+
+    using coords_type::begin;
+    using coords_type::cbegin;
+    using coords_type::cend;
+    using coords_type::end;
+    using coords_type::operator[];
 
   private:
     [[nodiscard]] friend constexpr auto
     close_to(Entity const& lhs, Entity const& rhs, coord_type tol) -> bool
     {
         return std::transform_reduce(
-            lhs.coords().cbegin(),
-            lhs.coords().cend(),
-            rhs.coords().cbegin(),
+            lhs.cbegin(),
+            lhs.end(),
+            rhs.cbegin(),
             true,
             std::logical_and{},
             [tol](auto x, auto y) { return std::abs(x - y) < tol; });
@@ -50,7 +59,7 @@ class Entity<Derived<T, N>> {
         os << "(";
         os << p.coords()[0];
 
-        for (auto x : p.coords() | std::views::drop(1)) { os << ", " << x; }
+        for (auto x : p | std::views::drop(1)) { os << ", " << x; }
 
         os << ")";
         return os;
@@ -60,24 +69,24 @@ class Entity<Derived<T, N>> {
     operator==(Entity const& lhs, Entity const& rhs) -> bool
     {
         return std::transform_reduce(
-            lhs.coords().cbegin(),
-            lhs.coords().cend(),
-            rhs.coords().cbegin(),
+            lhs.cbegin(),
+            lhs.cend(),
+            rhs.cbegin(),
             true,
             std::logical_and{},
             std::ranges::equal_to{});
     }
 
-    template <class... Args>
-    constexpr explicit Entity(coord_type x, Args&&... xs) : coords_({x, xs...})
-    {}
+    friend Derived<T, N>;
 
     constexpr Entity() = default;
 
-    constexpr Entity(coords_type coords) : coords_{std::move(coords)} {}
+    constexpr Entity(coords_type coords) : coords_type{std::move(coords)} {}
 
-    friend Derived<T, N>;
-    coords_type coords_{};
+    template <class... Args>
+    constexpr explicit Entity(coord_type x, Args&&... xs)
+        : coords_type({x, xs...})
+    {}
 };
 
 /// A simple vector class
@@ -86,6 +95,8 @@ class Vector : public Entity<Vector<T, N>> {
   public:
     static constexpr std::size_t size = N;
     using coord_type = typename Entity<Vector<T, N>>::coord_type;
+
+    Vector() = default;
 
     template <class... Args>
     constexpr Vector(Args&&... args)
@@ -96,7 +107,7 @@ class Vector : public Entity<Vector<T, N>> {
     [[nodiscard]] friend constexpr auto operator-(Vector const& v) -> Vector
     {
         auto r = Vector{};
-        std::ranges::transform(v.coords(), r.coords().begin(), std::negate{});
+        std::ranges::transform(v, r.begin(), std::negate{});
         return r;
     }
 
@@ -104,8 +115,7 @@ class Vector : public Entity<Vector<T, N>> {
     operator+(Vector const& v1, Vector const& v2) -> Vector
     {
         auto r = Vector{};
-        std::ranges::transform(
-            v1.coords(), v2.coords(), r.coords().begin(), std::plus{});
+        std::ranges::transform(v1, v2, r.begin(), std::plus{});
         return r;
     }
 
@@ -113,9 +123,7 @@ class Vector : public Entity<Vector<T, N>> {
     operator*(Vector const& v, Vector::coord_type const& s) -> Vector
     {
         auto r = Vector{};
-        std::ranges::transform(v.coords(), r.coords().begin(), [s](auto x) {
-            return s * x;
-        });
+        std::ranges::transform(v, r.begin(), [s](auto x) { return s * x; });
         return r;
     }
 
@@ -128,10 +136,7 @@ class Vector : public Entity<Vector<T, N>> {
     [[nodiscard]] friend constexpr auto norm(Vector const& v)
     {
         return std::inner_product(
-            v.coords().cbegin(),
-            v.coords().cend(),
-            v.coords().cbegin(),
-            Vector::coord_type{});
+            v.cbegin(), v.cend(), v.cbegin(), Vector::coord_type{});
     }
 };
 
@@ -140,6 +145,8 @@ template <class T, std::size_t N>
 class Point : public Entity<Point<T, N>> {
   public:
     static constexpr std::size_t size = N;
+
+    Point() = default;
 
     template <class... Args>
     constexpr Point(Args&&... args) : Entity<Point>(std::forward<Args>(args)...)
@@ -150,8 +157,7 @@ class Point : public Entity<Point<T, N>> {
     operator+(Point const& p, Vector<T, N> const& v) -> Point
     {
         auto r = Point{};
-        std::ranges::transform(
-            p.coords(), v.coords(), r.coords().begin(), std::plus{});
+        std::ranges::transform(p, v, r.begin(), std::plus{});
         return r;
     }
 };

--- a/src/spaces/spaces.hpp
+++ b/src/spaces/spaces.hpp
@@ -60,7 +60,10 @@ class Entity<Derived<T, N>> : std::array<T, N> {
         os << "(";
         os << p.coords()[0];
 
-        for (auto x : p | std::views::drop(1)) { os << ", " << x; }
+        // TODO use `std::views::drop` once clang implements it
+        for (auto x : std::ranges::drop_view{p, 1}) {
+            os << ", " << x;
+        }
 
         os << ")";
         return os;
@@ -101,7 +104,7 @@ class Vector : public Entity<Vector<T, N>> {
     [[nodiscard]] friend constexpr auto operator-(Vector const& v) -> Vector
     {
         auto r = Vector{};
-        std::ranges::transform(v, r.begin(), std::negate{});
+        std::transform(v.cbegin(), v.cend(), r.begin(), std::negate{});
         return r;
     }
 
@@ -109,7 +112,8 @@ class Vector : public Entity<Vector<T, N>> {
     operator+(Vector const& v1, Vector const& v2) -> Vector
     {
         auto r = Vector{};
-        std::ranges::transform(v1, v2, r.begin(), std::plus{});
+        std::transform(
+            v1.cbegin(), v1.cend(), v2.cbegin(), r.begin(), std::plus{});
         return r;
     }
 
@@ -117,7 +121,9 @@ class Vector : public Entity<Vector<T, N>> {
     operator*(Vector const& v, Vector::coord_type const& s) -> Vector
     {
         auto r = Vector{};
-        std::ranges::transform(v, r.begin(), [s](auto x) { return s * x; });
+        std::transform(v.cbegin(), v.cend(), r.begin(), [s](auto x) {
+            return s * x;
+        });
         return r;
     }
 
@@ -151,7 +157,8 @@ class Point : public Entity<Point<T, N>> {
     operator+(Point const& p, Vector<T, N> const& v) -> Point
     {
         auto r = Point{};
-        std::ranges::transform(p, v, r.begin(), std::plus{});
+        std::transform(
+            p.cbegin(), p.cend(), v.cbegin(), r.begin(), std::plus{});
         return r;
     }
 };

--- a/src/spaces/spaces.hpp
+++ b/src/spaces/spaces.hpp
@@ -67,16 +67,7 @@ class Entity<Derived<T, N>> : std::array<T, N> {
     }
 
     [[nodiscard]] friend constexpr auto
-    operator==(Entity const& lhs, Entity const& rhs) -> bool
-    {
-        return std::transform_reduce(
-            lhs.cbegin(),
-            lhs.cend(),
-            rhs.cbegin(),
-            true,
-            std::logical_and{},
-            std::ranges::equal_to{});
-    }
+    operator==(Entity const& lhs, Entity const& rhs) -> bool = default;
 
     friend Derived<T, N>;
 

--- a/src/spaces/spaces.hpp
+++ b/src/spaces/spaces.hpp
@@ -46,13 +46,22 @@ class Entity<Derived<T, N>> : std::array<T, N> {
     [[nodiscard]] friend constexpr auto
     close_to(Entity const& lhs, Entity const& rhs, coord_type tol) -> bool
     {
+        // TODO move to common location or replace with constexpr math lib
+        constexpr auto abs = [](auto x) {
+            if (x < decltype(x){}) {
+                return -x;
+            }
+
+            return x;
+        };
+
         return std::transform_reduce(
             lhs.cbegin(),
             lhs.end(),
             rhs.cbegin(),
             true,
             std::logical_and{},
-            [tol](auto x, auto y) { return std::abs(x - y) < tol; });
+            [abs, tol](auto x, auto y) { return abs(x - y) < tol; });
     }
 
     friend auto operator<<(std::ostream& os, Entity const& p) -> std::ostream&

--- a/src/spaces/spaces.hpp
+++ b/src/spaces/spaces.hpp
@@ -87,11 +87,13 @@ class Entity<Derived<T, N>> : std::array<T, N> {
 
     constexpr Entity(coords_type coords) : coords_type{std::move(coords)} {}
 
+    // NOLINTBEGIN(modernize-use-equals-delete)
     template <class... Args>
     requires(std::same_as<coord_type, std::remove_cvref_t<Args>>&&...)  //
         explicit(sizeof...(Args) == 1) constexpr Entity(Args&&... xs)
         : coords_type({std::forward<Args>(xs)...})
     {}
+    // NOLINTEND(modernize-use-equals-delete)
 };
 
 /// A simple vector class

--- a/src/spaces/spaces.hpp
+++ b/src/spaces/spaces.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <concepts>
 #include <functional>
 #include <iostream>
 #include <numeric>
@@ -84,8 +85,9 @@ class Entity<Derived<T, N>> : std::array<T, N> {
     constexpr Entity(coords_type coords) : coords_type{std::move(coords)} {}
 
     template <class... Args>
-    constexpr explicit Entity(coord_type x, Args&&... xs)
-        : coords_type({x, xs...})
+    requires(std::same_as<coord_type, std::remove_cvref_t<Args>>&&...)  //
+        explicit(sizeof...(Args) == 1) constexpr Entity(Args&&... xs)
+        : coords_type({std::forward<Args>(xs)...})
     {}
 };
 
@@ -99,7 +101,8 @@ class Vector : public Entity<Vector<T, N>> {
     Vector() = default;
 
     template <class... Args>
-    constexpr Vector(Args&&... args)
+    requires(std::same_as<coord_type, std::remove_cvref_t<Args>>&&...)  //
+        explicit(sizeof...(Args) == 1) constexpr Vector(Args&&... args)
         : Entity<Vector<T, N>>(std::forward<Args>(args)...)
     {}
 


### PR DESCRIPTION
Standard library algorithms are constexpr since C++17 so index sequence
tricks are no longer necessary for constexpr functions.