### PR TITLE
Add cos, sin and tests

### DIFF
--- a/src/math.hpp
+++ b/src/math.hpp
@@ -27,9 +27,57 @@ constexpr auto exp(T x)  // clang-format on
     return acc;
 }
 
+template <Arithmetic T>  // clang-format off
+  requires(not Dual<T>)
+constexpr auto cos(T x)  // clang-format on
+{
+    auto acc = decltype(x){1};
+    auto power = acc;
+    auto factorial = acc;
+
+    constexpr std::size_t taylor_terms{10U};
+    for (std::size_t i{1U}; i < taylor_terms; ++i) {
+        power *= x * x;
+        factorial *= static_cast<decltype(factorial)>((2 * i - 1) * (2 * i));
+
+        acc +=
+            (i % 2 == 0 ? decltype(x){1} : -decltype(x){1}) * power / factorial;
+    }
+    return acc;
+}
+
+template <Arithmetic T>  // clang-format off
+  requires(not Dual<T>)
+constexpr auto sin(T x)  // clang-format on
+{
+    auto acc = x;
+    auto power = x;
+    auto factorial = decltype(x){1};
+
+    constexpr std::size_t taylor_terms{10U};
+    for (std::size_t i{1U}; i < taylor_terms; ++i) {
+        power *= x * x;
+        factorial *= static_cast<decltype(factorial)>((2 * i) * (2 * i + 1));
+
+        acc +=
+            (i % 2 == 0 ? decltype(x){1} : -decltype(x){1}) * power / factorial;
+    }
+    return acc;
+}
+
 constexpr auto exp(Dual auto const& x)
 {
     return std::remove_cvref_t<decltype(x)>{exp(x.real), x.imag * exp(x.real)};
+}
+
+constexpr auto cos(Dual auto const& x)
+{
+    return std::remove_cvref_t<decltype(x)>{cos(x.real), -x.imag * sin(x.real)};
+}
+
+constexpr auto sin(Dual auto const& x)
+{
+    return std::remove_cvref_t<decltype(x)>{sin(x.real), x.imag * cos(x.real)};
 }
 
 }  // namespace opt

--- a/test/BUILD
+++ b/test/BUILD
@@ -6,6 +6,11 @@ opt_cc_test(
 )
 
 opt_cc_test(
+    name = "math",
+    size = "small",
+)
+
+opt_cc_test(
     name = "spaces",
     size = "small",
 )

--- a/test/math_test.cpp
+++ b/test/math_test.cpp
@@ -1,0 +1,41 @@
+#include "src/math.hpp"
+
+#include "boost/ut.hpp"
+
+#include <cmath>
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+auto main() -> int
+{
+    using namespace boost::ut;
+    using opt::dual;
+
+    constexpr dual x{1.0F, 2.0F};
+
+    test("dualnumbers math exp") = [&x] {
+        expect(eq(std::exp(1.0F), opt::exp(1.0F)));
+
+        expect(eq(opt::exp(x), dual{std::exp(1.0F), 2.0F * std::exp(1.0F)}));
+        expect(
+            eq(opt::exp(x * x), dual{std::exp(1.0F), 4.0F * std::exp(1.0F)}));
+    };
+
+    test("dualnumbers math cos") = [&x] {
+        expect(eq(std::cos(1.0F), opt::cos(1.0F)));
+
+        expect(eq(opt::cos(x), dual{std::cos(1.0F), -2.0F * std::sin(1.0F)}));
+        expect(
+            eq(opt::cos(x * x), dual{std::cos(1.0F), -4.0F * std::sin(1.0F)}));
+    };
+
+    test("dualnumbers math sin") = [&x] {
+        expect(eq(std::sin(1.0F), opt::sin(1.0F)));
+
+        expect(eq(opt::sin(x), dual{std::sin(1.0F), 2.0F * std::cos(1.0F)}));
+        expect(
+            eq(opt::sin(x * x), dual{std::sin(1.0F), 4.0F * std::cos(1.0F)}));
+    };
+}
+
+// NOLINTEND(readability-magic-numbers)


### PR DESCRIPTION
Add cos and sin constexpr functions and corresponding
method for dual numbers.

Add tests for exp, cos and sin, checking that the result is the same
as std:: algorithms (note: equal up to numerical precision, for larger
values than the ones tested it might be needed to increase the
number of elements of the taylor series).