### PR TITLE
WIP Pull in gcem for constexpr math functions

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -29,4 +29,7 @@ opt_cc_library(
     name = "optimizer",
     hdrs = [":headers"],
     visibility = ["//visibility:public"],
+    deps = [
+        "@gcem",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,6 +42,13 @@ new_git_repository(
     remote = "https://github.com/boost-ext/ut/",
 )
 
+new_git_repository(
+    name = "gcem",
+    build_file = "@//:external/gcem.BUILD",
+    commit = "4fb808a8e2969bfa1e3b2161bc9b7438338a4f50",
+    remote = "https://github.com/kthohr/gcem",
+)
+
 http_archive(
     name = "rules_python",
     sha256 = "954aa89b491be4a083304a2cb838019c8b8c3720a7abb9c4cb81ac7a24230cea",

--- a/bazel/rules.bzl
+++ b/bazel/rules.bzl
@@ -17,7 +17,8 @@ def opt_cc_test(name, **kwargs):
     ]
 
     if "deps" in kwargs:
-        full_deps = full_deps + kwargs.deps
+        full_deps = full_deps + kwargs["deps"]
+        kwargs.pop("deps")
 
     if "srcs" in kwargs:
         test_srcs = kwargs.srcs

--- a/external/gcem.BUILD
+++ b/external/gcem.BUILD
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "gcem",
+    hdrs = glob(["include/**/*.hpp"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/src/math.hpp
+++ b/src/math.hpp
@@ -2,6 +2,7 @@
 
 #include "concepts.hpp"
 #include "dualnumbers.hpp"
+#include "gcem.hpp"
 #include "impl/base_fn.hpp"
 #include "impl/series.hpp"
 
@@ -14,32 +15,17 @@ namespace impl {
 
 template <std::size_t N>
 inline constexpr auto exp_ = make_base_fn_<N>([]<Real T>(T x) -> T {
-    return series::sum_first<N>(series::geometric{
-        1U,    //
-        T{1},  //
-        [x](auto n) { return x / T(n); }});
+    return gcem::exp(x);
 });
 
 template <std::size_t N>
 inline constexpr auto sin_ = make_base_fn_<N>([]<Real T>(T x) -> T {
-    return series::sum_first<N>(series::geometric{
-        1U,  //
-        x,   //
-        [x](auto i) {
-            const auto n = T(i);
-            return (-1) * (x * x) / (2 * n) / (2 * n + 1);
-        }});
+    return gcem::sin(x);
 });
 
 template <std::size_t N>
 inline constexpr auto cos_ = make_base_fn_<N>([]<Real T>(T x) -> T {
-    return series::sum_first<N>(series::geometric{
-        1U,    //
-        T{1},  //
-        [x](auto i) {
-            const auto n = T(i);
-            return (-1) * (x * x) / (2 * n - 1) / (2 * n);
-        }});
+    return gcem::cos(x);
 });
 
 template <std::default_initializable F, std::default_initializable G>

--- a/test/BUILD
+++ b/test/BUILD
@@ -8,6 +8,9 @@ opt_cc_test(
 opt_cc_test(
     name = "math",
     size = "small",
+    deps = [
+        "@gcem",
+    ],
 )
 
 opt_cc_test(

--- a/test/math_test.cpp
+++ b/test/math_test.cpp
@@ -1,8 +1,7 @@
+#include "gcem.hpp"
 #include "src/math.hpp"
 
 #include "boost/ut.hpp"
-
-#include <cmath>
 
 // NOLINTBEGIN(readability-magic-numbers)
 
@@ -14,27 +13,27 @@ auto main() -> int
     constexpr dual x{1.0F, 2.0F};
 
     test("dualnumbers math exp") = [&x] {
-        expect(eq(std::exp(1.0F), opt::exp(1.0F)));
+        expect(eq(gcem::exp(1.0F), opt::exp(1.0F)));
 
-        expect(eq(opt::exp(x), dual{std::exp(1.0F), 2.0F * std::exp(1.0F)}));
+        expect(eq(opt::exp(x), dual{gcem::exp(1.0F), 2.0F * gcem::exp(1.0F)}));
         expect(
-            eq(opt::exp(x * x), dual{std::exp(1.0F), 4.0F * std::exp(1.0F)}));
+            eq(opt::exp(x * x), dual{gcem::exp(1.0F), 4.0F * gcem::exp(1.0F)}));
     };
 
     test("dualnumbers math cos") = [&x] {
-        expect(eq(std::cos(1.0F), opt::cos(1.0F)));
+        expect(eq(gcem::cos(1.0F), opt::cos(1.0F)));
 
-        expect(eq(opt::cos(x), dual{std::cos(1.0F), -2.0F * std::sin(1.0F)}));
-        expect(
-            eq(opt::cos(x * x), dual{std::cos(1.0F), -4.0F * std::sin(1.0F)}));
+        expect(eq(opt::cos(x), dual{gcem::cos(1.0F), -2.0F * gcem::sin(1.0F)}));
+        expect(eq(opt::cos(x * x),
+                  dual{gcem::cos(1.0F), -4.0F * gcem::sin(1.0F)}));
     };
 
     test("dualnumbers math sin") = [&x] {
-        expect(eq(std::sin(1.0F), opt::sin(1.0F)));
+        expect(eq(gcem::sin(1.0F), opt::sin(1.0F)));
 
-        expect(eq(opt::sin(x), dual{std::sin(1.0F), 2.0F * std::cos(1.0F)}));
+        expect(eq(opt::sin(x), dual{gcem::sin(1.0F), 2.0F * gcem::cos(1.0F)}));
         expect(
-            eq(opt::sin(x * x), dual{std::sin(1.0F), 4.0F * std::cos(1.0F)}));
+            eq(opt::sin(x * x), dual{gcem::sin(1.0F), 4.0F * gcem::cos(1.0F)}));
     };
 }
 


### PR DESCRIPTION
WIP math tests fail due to numerical errors

Use gcem instead of our own method for math functions.

We might want to keep alive the Taylor series expansion anyway so
it is possible to use that instead of gcem if the specific
function is not in their library.